### PR TITLE
Fix environment variable loading for LLM agents

### DIFF
--- a/llm/agents.py
+++ b/llm/agents.py
@@ -1,6 +1,11 @@
 import asyncio
 import httpx
 import os
+import dotenv
+
+# Ensure environment variables from a .env file are available before
+# we construct any request headers that rely on them.
+dotenv.load_dotenv()
 
 OPENROUTER_BASE = "https://openrouter.ai/api/v1/chat/completions"
 HEADERS = {


### PR DESCRIPTION
## Summary
- load environment variables before constructing API request headers

## Testing
- `python -m py_compile app.py llm/agents.py llm/aggregator.py routes/chat.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ee2d81c4832ab009d8f9a164dbfa